### PR TITLE
Remove IP addresses from logs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ npm install
 npm test
 ```
 
-このコマンドではサーバを起動し、正常ログと異常ログを取得します。生成されたログは `resource/logs/normal_log.csv` と `resource/logs/abnormal_log.csv` に保存されます。
+このコマンドではサーバを起動し、正常ログと異常ログを取得します。生成されたログは `resource/logs/normal_log.csv` と `resource/logs/abnormal_log.csv` に保存されます。IPアドレスはプライバシー保護のため記録されません。
 
 ### 正常ログの取得
 

--- a/resource/abnormal_logger.js
+++ b/resource/abnormal_logger.js
@@ -16,21 +16,7 @@ const SECRET = 'change_this_to_env_secret';
 const LOG_FILE = path.join(__dirname, 'logs', 'abnormal_log.csv');
 const API_VERSION = 'v1';
 
-const jpOctets = new Set([
-  43,49,58,59,60,61,101,103,106,110,111,112,113,114,115,116,118,
-  119,120,121,122,123,124,125,126,133,150,153,175,180,182,183,202,
-  203,210,211,219,220,221,222
-]);
-
-function lookupRegion(ip) {
-  if (!ip) return '-';
-  const first = parseInt(ip.split('.')[0], 10);
-  if (jpOctets.has(first)) return 'JP';
-  if (first <= 126) return 'NA';
-  if (first <= 191) return 'EU';
-  if (first <= 223) return 'AP';
-  return '-';
-}
+// IP判定ロジックは使用しないので除去
 
 function getUserRole(user_id) {
   if (!user_id) return 'guest';
@@ -41,11 +27,10 @@ function getUserRole(user_id) {
 
 const lastEndpoint = new Map();
 
-// logging fields (server.js と同一順)
+// logging fields (IP は記録しない)
 const FIELDS = [
   'timestamp',
   'session_id',
-  'ip',
   'user_agent',
   'jwt',
   'method',
@@ -149,7 +134,6 @@ async function requestAndLog({ method, endpoint, data, token, userId, ip, label,
   const log = {
     timestamp: new Date(start).toISOString(),
     session_id: token ? token.slice(-8) : 'guest',
-    ip,
     user_agent: USER_AGENT,
     jwt: token || '',
     method: method.toUpperCase(),

--- a/resource/normal_logger.js
+++ b/resource/normal_logger.js
@@ -14,21 +14,7 @@ const updateOperationLog = require('./update_operation_log');
 const LOG_FILE = path.join(__dirname, 'logs', 'normal_log.csv');
 const API_VERSION = 'v1';
 
-const jpOctets = new Set([
-  43,49,58,59,60,61,101,103,106,110,111,112,113,114,115,116,118,
-  119,120,121,122,123,124,125,126,133,150,153,175,180,182,183,202,
-  203,210,211,219,220,221,222
-]);
-
-function lookupRegion(ip) {
-  if (!ip) return '-';
-  const first = parseInt(ip.split('.')[0], 10);
-  if (jpOctets.has(first)) return 'JP';
-  if (first <= 126) return 'NA';
-  if (first <= 191) return 'EU';
-  if (first <= 223) return 'AP';
-  return '-';
-}
+// IPによる地域判定は使用しないため削除
 
 function getUserRole(user_id) {
   if (!user_id) return 'guest';
@@ -39,11 +25,10 @@ function getUserRole(user_id) {
 
 const lastEndpoint = new Map();
 
-// logging fields (server.js と同一順)
+// logging fields (IP は記録しない)
 const FIELDS = [
   'timestamp',
   'session_id',
-  'ip',
   'user_agent',
   'jwt',
   'method',
@@ -150,7 +135,6 @@ async function requestAndLog({ method, endpoint, data, token, userId, ip, label 
   const log = {
     timestamp: new Date(start).toISOString(),
     session_id: actualToken ? actualToken.slice(-8) : 'guest',
-    ip,
     user_agent: USER_AGENT,
     jwt: actualToken || '',
     method: method.toUpperCase(),

--- a/resource/preprocess_log_to_mat.py
+++ b/resource/preprocess_log_to_mat.py
@@ -25,13 +25,14 @@ def preprocess(df):
     method_codes, method_uniques = pd.factorize(df["method"])
     df["method_code"] = method_codes
 
-    def ip_to_int(x):
-        try:
-            return int(ipaddress.ip_address(x))
-        except Exception:
-            return -1
+    if "ip" in df.columns:
+        def ip_to_int(x):
+            try:
+                return int(ipaddress.ip_address(x))
+            except Exception:
+                return -1
 
-    df["ip_int"] = df["ip"].apply(ip_to_int)
+        df["ip_int"] = df["ip"].apply(ip_to_int)
 
     seq_series = df.groupby("session_id")["endpoint_code"].apply(lambda x: np.array(x, dtype=np.int32))
     sequences = seq_series.tolist()

--- a/src/middlewares/recordSession.js
+++ b/src/middlewares/recordSession.js
@@ -2,23 +2,12 @@ const crypto = require('crypto');
 const csv = require('../utils/csvWriter');
 const { v4: uuid } = require('uuid');
 
-const jpOctets = new Set([43,49,58,59,60,61,101,103,106,110,111,112,113,114,
- 115,116,118,119,120,121,122,123,124,125,126,133,150,153,175,180,182,183,202,
- 203,210,211,219,220,221,222]);
-function lookupRegion(ip) {
-  if (!ip) return '-';
-  const first = parseInt(ip.split('.')[0], 10);
-  if (jpOctets.has(first)) return 'JP';
-  if (first <= 126) return 'NA';
-  if (first <= 191) return 'EU';
-  if (first <= 223) return 'AP';
-  return '-';
-}
+// IP判定系のロジックは使用しないため削除
 
 // セッションおよびトークン単位の状態保存
 // last プロパティに最終アクセス時刻を保持する
 const sessions = new Map(); // session_id -> {start,last,prev,repeat,lastBodyKeys}
-const tokenMap = new Map(); // token -> {ip, ua, last}
+const tokenMap = new Map(); // token -> {ua, last}
 
 // エントリ保持期間 (1時間)
 const EXPIRE_MS = 60 * 60 * 1000;
@@ -58,13 +47,11 @@ module.exports = function recordSession(req, res, next) {
 
     const ua  = req.get('user-agent') || '-';
     const ref = req.get('referer') || '-';
-    const ip  = req.ip;
     const auth = req.get('authorization');
 
     csv.writeRecords([{
       ts: new Date(now).toISOString(),
       session_id: sid,
-      ip,
       user_agent: ua,
       jwt: auth ? auth.split(' ')[1] : '-',
       method: req.method,

--- a/src/utils/csvWriter.js
+++ b/src/utils/csvWriter.js
@@ -12,7 +12,6 @@ function getCsvWriter() {
     header: [
       { id: 'ts',         title: 'ts' },
       { id: 'session_id', title: 'session_id' },
-      { id: 'ip',         title: 'ip' },
       { id: 'user_agent', title: 'user_agent' },
       { id: 'jwt',        title: 'jwt' },
       { id: 'method',     title: 'method' },


### PR DESCRIPTION
## Summary
- logging scripts now exclude IP addresses
- server and middleware updated to omit IPs
- preprocessing handles missing IP columns
- update README with privacy note

## Testing
- `npm run unit-test`

------
https://chatgpt.com/codex/tasks/task_e_686f68e08b8c83278b5148c4b6c40452